### PR TITLE
Sets back mio dependency git URL to the original one

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,4 @@ nix = "*"
 coroutine = "*"
 
 [dependencies.mio]
-# TODO: switch to upstream when possible
-git = "https://github.com/dpc/mio.git"
+git = "https://github.com/carllerche/mio"

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -93,7 +93,7 @@ impl Server {
                     }
                 }
             };
-            let _tok = self.conns.create_and_insert(|token| {
+            let _tok = self.conns.insert_with(|token| {
                 mioco::Coroutine::new(sock, event_loop, token, f)
             });
         }


### PR DESCRIPTION
This fixes the build with rustc 1.3.0-nightly e5a28bca7 2015-06-25