### PR TITLE
Use count leading zeroes to speed up sparse bitvec.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,8 @@ spin = "*"
 time = "*"
 context = "*"
 mio = "0.4.*"
-bit-vec = "0.4.*"
+# Until: https://github.com/contain-rs/bit-vec/pull/21 is not published
+#bit-vec = "0.4.*"
+
+[dependencies.bit-vec]
+git = "https://github.com/contain-rs/bit-vec.git"


### PR DESCRIPTION
This is broken until bitvec fix is merged: https://github.com/contain-rs/bit-vec/pull/21