### PR TITLE
RX doesn't have to be mut to be used

### DIFF
--- a/examples/mailbox.rs
+++ b/examples/mailbox.rs
@@ -41,7 +41,7 @@ fn main() {
 
         println!("Starting tcp echo server on {:?}", sock.local_addr().unwrap());
         let sock = mioco.wrap(sock);
-        let mut mail_recv = mioco.wrap(mail_recv);
+        let mail_recv = mioco.wrap(mail_recv);
 
         loop {
             let _ = mail_recv.read();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1460,7 +1460,7 @@ where T : Reflect+'static {
     /// Receive `T` sent using corresponding `MailboxOuterEnd::send()`.
     ///
     /// Will block coroutine if no elements are available.
-    pub fn read(&mut self) -> T {
+    pub fn read(&self) -> T {
         loop {
             if let Some(t) = self.try_read() {
                 return t
@@ -1471,7 +1471,7 @@ where T : Reflect+'static {
     }
 
     /// Try reading current time (if the timer is done)
-    pub fn try_read(&mut self) -> Option<T> {
+    pub fn try_read(&self) -> Option<T> {
         let mut inn = self.inn.borrow_mut();
         let handle = inn.io.as_any_mut().downcast_mut::<MailboxInnerEnd<T>>().unwrap();
         let mut lock = handle.shared.lock();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -314,7 +314,7 @@ fn exit_notifier_simple() {
             Ok(())
         }).exit_notificator();
 
-        let mut notify = mioco.wrap(notify);
+        let notify = mioco.wrap(notify);
 
         assert!(!notify.read().is_panic());
 
@@ -337,7 +337,7 @@ fn exit_notifier_simple_panic() {
             panic!()
         }).exit_notificator();
 
-        let mut notify = mioco.wrap(notify);
+        let notify = mioco.wrap(notify);
 
         assert!(notify.read().is_panic());
 
@@ -364,18 +364,18 @@ fn exit_notifier_wrap_after_finish() {
         let notify1 = handle1.exit_notificator();
 
         let handle2 = mioco.spawn(move |mioco| {
-            let mut notify1 = mioco.wrap(notify1);
+            let notify1 = mioco.wrap(notify1);
             assert!(notify1.read().is_panic());
             Ok(())
         });
 
         let notify2 = handle2.exit_notificator();
-        let mut notify2 = mioco.wrap(notify2);
+        let notify2 = mioco.wrap(notify2);
         assert!(!notify2.read().is_panic());
 
 
         let notify1 = handle1.exit_notificator();
-        let mut notify1 = mioco.wrap(notify1);
+        let notify1 = mioco.wrap(notify1);
         assert!(notify1.read().is_panic());
 
 


### PR DESCRIPTION
This commit changes `MailboxInnerEnd` methods to accept self by immutable reference instead of mutable. It gives us more similar API comparing with `mpsc::Receiver`.

See https://doc.rust-lang.org/nightly/std/sync/mpsc/struct.Receiver.html for more.

Also it allows us not to write scary things like:
```rust
let (tx, mut rx) = ...;
```

**WARNING:** This change breaks ABI.