### PR TITLE
Fix path to `mio` crate in documentation.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@
 */
 //! [green threads]: https://en.wikipedia.org/wiki/Green_threads
 //! [mio]: https://github.com/carllerche/mio
-//! [mio-api]: ./mioco/mio/index.html
+//! [mio-api]: ../mioco/mio/index.html
 
 #![cfg_attr(test, feature(convert))]
 #![feature(reflect_marker)]


### PR DESCRIPTION
Currently the link is leading to [404 page](http://dpc.pw/mioco/mioco/mioco/mio/index.html)

Fix it to http://dpc.pw/mioco/mio/index.html