### PR TITLE
Block on write when connecting to TcpStream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,4 @@ slab = "*"
 [dev-dependencies]
 env_logger = "*"
 httparse = "*"
+net2 = "0.2.21"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,8 @@
 
 #[cfg(test)]
 extern crate env_logger;
+#[cfg(test)]
+extern crate net2;
 
 extern crate thread_scoped;
 extern crate libc;

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -118,13 +118,21 @@ impl AsRawFd for TcpStream {
 impl TcpStream {
     /// Create a new TCP stream an issue a non-blocking connect to the specified address.
     pub fn connect(addr: &SocketAddr) -> io::Result<Self> {
-        mio_orig::tcp::TcpStream::connect(addr).map(|t| TcpStream(RcEvented::new(t)))
+        mio_orig::tcp::TcpStream::connect(addr).map(|t| {
+            let stream = TcpStream(RcEvented::new(t));
+            stream.block_on(RW::write());
+            stream
+        })
     }
 
     /// Creates a new TcpStream from the pending socket inside the given
     /// `std::net::TcpBuilder`, connecting it to the address specified.
     pub fn connect_stream(stream: std::net::TcpStream, addr: &SocketAddr) -> io::Result<Self> {
-        mio_orig::tcp::TcpStream::connect_stream(stream, addr).map(|t| TcpStream(RcEvented::new(t)))
+        mio_orig::tcp::TcpStream::connect_stream(stream, addr).map(|t| {
+            let stream = TcpStream(RcEvented::new(t));
+            stream.block_on(RW::write());
+            stream
+        })
     }
 
     /// Local address of connection.


### PR DESCRIPTION
Fixed bug where writing to TcpStream could result in a "Socket is not
connected" error. The `tcp_basic_client_server` test has been updated to
ensure a pending socket connection will block when trying to write.

Fixes #83.