### PR TITLE
Provide (Pre-)Alpha Windows Support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,104 @@
+## Operating System (VM environment) ##
+
+# Rust needs at least Visual Studio 2013 Appveyor OS for MSVC targets.
+os: Visual Studio 2015
+
+## Build Matrix ##
+
+# This configuration will setup a build for each channel & target combination (12 windows
+# combinations in all).
+#
+# There are 3 channels: stable, beta, and nightly.
+#
+# The values for target are the set of windows Rust build targets. Each value is of the form
+#
+# ARCH-pc-windows-TOOLCHAIN
+#
+# Where ARCH is the target architecture, either x86_64 or i686, and TOOLCHAIN is the linker
+# toolchain to use, either msvc or gnu. See https://www.rust-lang.org/downloads.html#win-foot for
+# a description of the toolchain differences.
+#
+# Comment out channel/target combos you do not wish to build in CI.
+environment:
+  matrix:
+
+### MSVC Toolchains ###
+
+   #Nightly 64-bit MSVC
+    - channel: nightly
+      target: x86_64-pc-windows-msvc
+   #Nightly 32-bit MSVC
+    - channel: nightly
+      target: i686-pc-windows-msvc
+
+### GNU Toolchains ###
+
+  # Nightly 64-bit GNU
+    - channel: nightly
+      target: x86_64-pc-windows-gnu
+  # Nightly 32-bit GNU
+    - channel: nightly
+      target: i686-pc-windows-gnu
+
+### Allowed failures ###
+
+# See Appveyor documentation for specific details. In short, place any channel or targets you wish
+# to allow build failures on (usually nightly at least is a wise choice). This will prevent a build
+# or test failure in the matching channels/targets from failing the entire build.
+matrix:
+  allow_failures:
+    #- channel: nightly
+
+# If you only care about stable channel build failures, uncomment the following line:
+    #- channel: beta
+
+# 32-bit MSVC isn't stablized yet, so you may optionally allow failures there (uncomment line):
+    - target: i686-pc-windows-msvc
+
+# 64-bit GNU gcc does not have 64-bit mode compiled in. Lets leave it enabled, maybe that changes quickly.
+    - target: x86_64-pc-windows-gnu
+
+## Install Script ##
+
+# This is the most important part of the Appveyor configuration. This installs the version of Rust
+# specified by the 'channel' and 'target' environment variables from the build matrix. By default,
+# Rust will be installed to C:\Rust for easy usage, but this path can be overridden by setting the
+# RUST_INSTALL_DIR environment variable. The URL to download rust distributions defaults to
+# https://static.rust-lang.org/dist/ but can overridden by setting the RUST_DOWNLOAD_URL environment
+# variable.
+#
+# For simple configurations, instead of using the build matrix, you can override the channel and
+# target environment variables with the -channel and -target script arguments.
+#
+# If no channel or target arguments or environment variables are specified, will default to stable
+# channel and x86_64-pc-windows-msvc target.
+#
+# The file appveyor_rust_install.ps1 must exist in the root directory of the repository.
+install:
+- ps: .\appveyor_rust_install.ps1
+
+# Alternative install command for simple configurations without build matrix (uncomment line and
+# comment above line):
+#- ps: .\appveyor_rust_install.ps1 -channel stable -target x86_64-pc-windows-msvc
+
+## Build Script ##
+
+# Uses 'cargo build' to build. Alternatively, the project may call rustc directly or perform other
+# build commands. Rust will automatically be placed in the PATH environment variable.
+build_script:
+- cmd: cargo build --verbose
+
+## Build Script ##
+
+# Uses 'cargo test' to run tests. Alternatively, the project may call compiled programs directly or
+# perform other testing commands. Rust will automatically be placed in the PATH environment
+# variable.
+test_script:
+- cmd: cargo test
+
+# Only build against the branches that will have pull requests built against them (master).
+# Otherwise creating feature branches on this repository and a pull requests against them will
+# cause each commit to be tested twice, once for the branch and once for the pull request.
+branches:
+  only:
+    - master

--- a/appveyor_rust_install.ps1
+++ b/appveyor_rust_install.ps1
@@ -1,0 +1,66 @@
+##### Appveyor Rust Install Script #####
+
+# This is the most important part of the Appveyor configuration. This installs the version of Rust
+# specified by the "channel" and "target" environment variables from the build matrix. By default,
+# Rust will be installed to C:\Rust for easy usage, but this path can be overridden by setting the
+# RUST_INSTALL_DIR environment variable. The URL to download rust distributions defaults to
+# https://static.rust-lang.org/dist/ but can overridden by setting the RUST_DOWNLOAD_URL environment
+# variable.
+#
+# For simple configurations, instead of using the build matrix, you can override the channel and
+# target environment variables with the --channel and --target script arguments.
+#
+# If no channel or target arguments or environment variables are specified, will default to stable
+# channel and x86_64-pc-windows-msvc target.
+
+param([string]$channel=${env:channel}, [string]$target=${env:target})
+
+# Initialize our parameters from arguments and environment variables, falling back to defaults
+if (!$channel) {
+    $channel = "stable"
+}
+if (!$target) {
+    $target = "x86_64-pc-windows-msvc"
+}
+
+$downloadUrl = "https://static.rust-lang.org/dist/"
+if ($env:RUST_DOWNLOAD_URL) {
+    $downloadUrl = $env:RUST_DOWNLOAD_URL
+}
+
+$installDir = "C:\Rust"
+if ($env:RUST_INSTALL_DIR) {
+    $installUrl = $env:RUST_INSTALL_DIR
+}
+
+# Download manifest so we can find actual filename of installer to download. Needed mostly for
+# stable channel.
+echo "Downloading $channel channel manifest"
+$manifest = "${env:Temp}\channel-rust-${channel}"
+Start-FileDownload "${downloadUrl}channel-rust-${channel}" -FileName "$manifest"
+
+# Search the manifest lines for the correct filename based on target
+$match = Get-Content "$manifest" | Select-String -pattern "${target}.exe" -simplematch
+
+if (!$match -or !$match.line) {
+    throw "Could not find $target in $channel channel manifest"
+}
+
+$installer = $match.line
+
+# Download installer
+echo "Downloading ${downloadUrl}$installer"
+Start-FileDownload "${downloadUrl}$installer" -FileName "${env:Temp}\$installer"
+
+# Execute installer and wait for it to finish
+echo "Installing $installer to $installDir"
+&"${env:Temp}\$installer" /VERYSILENT /NORESTART /DIR="$installDir" | Write-Output
+
+# Add Rust to the path.
+$env:Path += ";${installDir}\bin;C:\MinGW\bin"
+
+echo "Installation of $channel Rust $target completed"
+
+# Test and display installed version information for rustc and cargo
+rustc -V
+cargo -V

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,11 +145,11 @@ pub mod sync;
 /// Timers
 pub mod timer;
 /// Unix sockets IO
+#[cfg(not(windows))]
 pub mod unix;
 /// TCP IO
 pub mod tcp;
 /// UDP IO
-#[cfg(not(windows))]
 pub mod udp;
 
 pub use evented::{Evented, MioAdapter};


### PR DESCRIPTION
Fixes #93.

Since your context-rs 1.0 fix everything seems to work now.
I tried to work around the missing mio pipe on windows by creating a custom pipe like struct based on channels. However although it seems to work for some tests, `lots_of_event_sources` and `long_chain` are still not working (but I believe this is caused by `read` returning and aborting to early).

The tcp test is broken on AppVeyor, I have no idea, if it would work on a real windows system, so thats also commented out.

I have also added configurations for AppVeyor CI.
As you can see https://ci.appveyor.com/project/Drakulix/mioco everything else is working, except for the x86_64-gnu target, which seems to be caused by a broken gcc on AppVeyor's MSYS2. The target gets build (in hope we notice, that it is fixed sometime in the future), but not actually required for a successful test.

Thats the best I can provide for now.