### PR TITLE
Fixed mismatched types error under Rust nightly 1.8.0

### DIFF
--- a/src/evented.rs
+++ b/src/evented.rs
@@ -310,7 +310,7 @@ pub trait RcEventSourceTrait {
 }
 
 /// Common control data for all event sources.
-struct EventSourceCommon {
+pub struct EventSourceCommon {
     pub id: Option<EventSourceId>,
     pub blocked_on: RW,
     pub peer_hup: bool,


### PR DESCRIPTION
Fixed build error on rust nightly where evented.rs was attempting to use a private type in a public interface. All unit tests still pass under `1.8.0-nightly` (`15e9a95a4` 2016-02-26)