### PR TITLE
Ignore `tcp_basic_client_server` on Windows.

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -992,7 +992,7 @@ fn simple_mutex() {
 }
 
 #[test]
-#[cfg(not(windows))]
+#[cfg_attr(windows, ignore)] // Issue #105
 fn tcp_basic_client_server() {
     use std::str::FromStr;
     for &threads in THREADS_N.iter() {


### PR DESCRIPTION
Issue #105