### PR TITLE
Update owning_ref version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ thread-scoped = "1.0.0"
 context = "1.0.0"
 slab = "0.2.0"
 clippy = {version = "0.0.77", optional = true}
-owning_ref = "0.1.4"
+owning_ref = "0.2.0"
 
 [dev-dependencies]
 env_logger = "0.3.2"


### PR DESCRIPTION
To include https://github.com/Kimundi/owning-ref-rs/commit/87b48117bd71f5e1e111484796e76be6953b27f1, which is needed because of rust-lang/rust#35143.
Without that soundness fix, any user of `erase_owner` could miss a lifetime and cause use after free.