### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ repository = "https://github.com/dpc/mioco"
 readme = "README.md"
 
 [dependencies]
-mio = "0.6.6"
+mio = "0.6"
 lazy_static = "*"
-num_cpus = "1.0.0"
+num_cpus = "*"
 context = "1"
 #slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
 slog = "2"
@@ -22,7 +22,7 @@ slog-async = "2"
 slab = "*"
 
 [dev-dependencies]
-env_logger = "0.3.2"
-httparse = "1.1.1"
-net2 = "0.2.26"
-rand = "0.3.14"
+env_logger = "0.6"
+httparse = "1"
+net2 = "0.2"
+rand = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://dpc.github.io/mioco/"
 homepage = "https://github.com/dpc/mioco"
 repository = "https://github.com/dpc/mioco"
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
 mio = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 mio = "0.6"
 lazy_static = "*"
 num_cpus = "*"
-context = "1"
+context = "2"
 #slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"] }
 slog = "2"
 slog-term = "~2.0.0-4"

--- a/examples/cheating-http-server.rs
+++ b/examples/cheating-http-server.rs
@@ -19,7 +19,7 @@ Hello World\r
 \r";
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
     let addr = listend_addr();
 
     let listener = TcpListener::bind(&addr).unwrap();

--- a/examples/echoplus.rs
+++ b/examples/echoplus.rs
@@ -29,19 +29,19 @@ fn main() {
     let _join = mioco::spawn(|| -> io::Result<()> {
         let addr = listend_addr();
 
-        let listener = try!(TcpListener::bind(&addr));
+        let listener = TcpListener::bind(&addr)?;
 
-        printerrln!("Starting tcp echo server on {:?}", try!(listener.local_addr()));
+        printerrln!("Starting tcp echo server on {:?}", listener.local_addr()?);
 
         loop {
-            let (mut conn, _addr) = try!(listener.accept());
+            let (mut conn, _addr) = listener.accept()?;
 
             let _join = mioco::spawn(move || -> io::Result<()> {
                 let mut buf = vec![0u8; 1024 * 64];
                 loop {
-                    let size = try!(conn.read(&mut buf));
+                    let size = conn.read(&mut buf)?;
                     if size == 0 {/* eof */ break; }
-                    let _ = try!(conn.write_all(&mut buf[0..size]));
+                    let _ = conn.write_all(&mut buf[0..size])?;
                 }
 
                 Ok(())

--- a/examples/http-server.rs
+++ b/examples/http-server.rs
@@ -46,7 +46,7 @@ fn main() {
 
                             loop {
                                 let mut headers = [httparse::EMPTY_HEADER; 16];
-                                let len = try!(conn.read(&mut buf[buf_i..]));
+                                let len = conn.read(&mut buf[buf_i..])?;
 
                                 if len == 0 {
                                     return Ok(());
@@ -61,14 +61,14 @@ fn main() {
                                     let req_len = res.unwrap();
                                     match req.path {
                                         Some(ref _path) => {
-                                            let _ = try!(conn.write_all(&RESPONSE.as_bytes()));
+                                            let _ = conn.write_all(&RESPONSE.as_bytes())?;
                                             if req_len != buf_i {
                                                 // request has a body; TODO: handle it
                                             }
                                             buf_i = 0;
                                         }
                                         None => {
-                                            let _ = try!(conn.write_all(&RESPONSE_404.as_bytes()));
+                                            let _ = conn.write_all(&RESPONSE_404.as_bytes())?;
                                             return Ok(());
                                         }
                                     }

--- a/examples/http-server.rs
+++ b/examples/http-server.rs
@@ -25,7 +25,7 @@ Hello World";
 
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
     let addr = listend_addr();
 
     let listener = TcpListener::bind(&addr).unwrap();

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -1,5 +1,5 @@
 use std::io as sio;
-use {in_coroutine, offload};
+use crate::{in_coroutine, offload};
 use std;
 use std::path::Path;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,7 +171,9 @@ fn pop_transfer() -> context::Transfer {
 }
 
 fn co_switch_out() {
-    let t = pop_transfer().context.resume(0);
+    let t = unsafe {
+        pop_transfer().context.resume(0)
+    };
     save_transfer(t);
 }
 
@@ -194,7 +196,9 @@ extern "C" fn context_function(t: context::Transfer) -> ! {
             cell.borrow_mut().take().unwrap()
         };
 
-        let t = t.context.resume(0);
+        let t = unsafe {
+            t.context.resume(0)
+        };
 
         save_transfer(t);
 
@@ -202,7 +206,9 @@ extern "C" fn context_function(t: context::Transfer) -> ! {
     }
 
     loop {
-        save_transfer(pop_transfer().context.resume(1));
+        save_transfer(unsafe{
+            pop_transfer().context.resume(1)
+        });
     }
 }
 
@@ -233,8 +239,12 @@ impl Fiber {
 
         let stack = stack::ProtectedFixedSizeStack::default();
 
-        let context = context::Context::new(&stack, context_function);
-        let t = context.resume(&f as *const _ as usize);
+        let context = unsafe {
+            context::Context::new(&stack, context_function)
+        };
+        let t = unsafe {
+            context.resume(&f as *const _ as usize)
+        };
         debug_assert!(f.borrow().is_none());
 
         trace!(log, "fiber created");
@@ -248,7 +258,9 @@ impl Fiber {
     fn resume(&mut self, loop_id: LoopId, fiber_id: FiberId) {
         TL_LOOP_ID.with(|id| id.set(loop_id));
         TL_FIBER_ID.with(|id| id.set(fiber_id));
-        let t = self.cur_context.take().unwrap().resume(0);
+        let t = unsafe {
+            self.cur_context.take().unwrap().resume(0)
+        };
         self.cur_context = Some(t.context);
         TL_LOOP_ID.with(|id| id.set(TL_LOOP_ID_NONE));
         TL_FIBER_ID.with(|id| id.set(TL_FIBER_ID_NONE));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,7 @@
-extern crate mio;
 #[macro_use]
 extern crate lazy_static;
-extern crate context;
 #[macro_use]
 extern crate slog;
-extern crate slog_term;
-extern crate slog_async;
-extern crate slab;
-extern crate num_cpus;
 
 use slog::{Logger, Drain};
 

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -33,7 +33,7 @@ impl TcpListener {
     }
 
     /// Creates a new TcpListener from an instance of a `std::net::TcpListener` type.
-    pub fn from_listener(listener: std::net::TcpListener, addr: &SocketAddr) -> io::Result<Self> {
+    pub fn from_listener(listener: std::net::TcpListener, _addr: &SocketAddr) -> io::Result<Self> {
         mio::tcp::TcpListener::from_std(listener).map(AsyncIO::new)
     }
 

--- a/src/sync/broadcast.rs
+++ b/src/sync/broadcast.rs
@@ -1,7 +1,7 @@
 //! Broadcast allows waking up multiple receivers at once
 use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use {MIOCO, co_switch_out, get_cur_fullid, FullId};
+use crate::{MIOCO, co_switch_out, get_cur_fullid, FullId};
 use std::collections::HashSet;
 use std::mem;
 use std::cell::RefCell;

--- a/src/sync/mpsc.rs
+++ b/src/sync/mpsc.rs
@@ -90,7 +90,7 @@ impl<T> Sender<T> {
     ///
     /// This is non-blocking operation.
     pub fn send(&self, t: T) -> Result<(), mpsc::SendError<T>> {
-        try!(self.tx.as_ref().unwrap().send(t));
+        self.tx.as_ref().unwrap().send(t)?;
         self.notif_tx.notify();
         Ok(())
     }

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -1,5 +1,5 @@
 use super::broadcast;
-use {in_coroutine};
+use crate::in_coroutine;
 
 use std::sync as ssync;
 use std::ops;

--- a/src/sync/notify.rs
+++ b/src/sync/notify.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, AtomicBool, Ordering};
-use {MIOCO, LoopMsg, FiberId, co_switch_out, TL_LOOP_ID, TL_FIBER_ID};
+use crate::{MIOCO, LoopMsg, FiberId, co_switch_out, TL_LOOP_ID, TL_FIBER_ID};
 use std;
 
 struct Shared {


### PR DESCRIPTION
This PR updates the dependencies to newer versions.

The `Context` crate version 2 makes all calls `unsafe`.
I therefore just wrapped all calls to `Context::new` and `resume` into an unsafe block.

The PR also removes a the `printerrln` macro from `latency.rs`, as it is not needed anymore.